### PR TITLE
Путь к файлу превью, когда джумла установлена в подпапку

### DIFF
--- a/plg_content_ytvideo/ytvideo.php
+++ b/plg_content_ytvideo/ytvideo.php
@@ -11,6 +11,7 @@ use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\FileSystem\Path;
+use Joomla\CMS\Uri\Uri;
 
 class plgContentYtvideo extends CMSPlugin
 {
@@ -125,16 +126,16 @@ class plgContentYtvideo extends CMSPlugin
                             $resultImage = true;
                             if ($cachFolder) {
                                 file_put_contents($cachedImage, $buffer);
-                                $image = str_replace('\\', '/', str_replace(Path::clean(JPATH_ROOT), '', $cachedImage));
+                                $image = Uri::base(true) . str_replace('\\', '/', str_replace(Path::clean(JPATH_ROOT), '', $cachedImage));
                             }
                             break;
                         }
                     }
                     if (!$resultImage || !file_exists($cachedImage)) {
-                        $image = '/' . $this->params->get('emptyimg', 'plugins/content/ytvideo/assets/empty' . ($isWebP ? '.webp' : '.png'));
+                        $image = Uri::base(true) . '/' . $this->params->get('emptyimg', 'plugins/content/ytvideo/assets/empty' . ($isWebP ? '.webp' : '.png'));
                     }
                 } else {
-                    $image = str_replace('\\', '/', str_replace(Path::clean(JPATH_ROOT), '', $cachedImage));
+                    $image = Uri::base(true) . str_replace('\\', '/', str_replace(Path::clean(JPATH_ROOT), '', $cachedImage));
                 }
 
                 ob_start();


### PR DESCRIPTION
Когда джумла установлена в подпапку, плагин подсавляет превьюшку от корня сайта, не учитывая в адресе подпапку.
Uri::base(true) - исправляет ситуацию